### PR TITLE
Config file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+/m68kmake
+/m68kmake.exe
+/m68kops.c
+/m68kops.h

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXENAME          = emulator
 
-MAINFILES        = emulator.c Gayle.c ide.c
+MAINFILES        = emulator.c Gayle.c ide.c memory_mapped.c config_file/config_file.c registers/registers_amiga.c
 MUSASHIFILES     = m68kcpu.c softfloat/softfloat.c 
 MUSASHIGENCFILES = m68kops.c
 MUSASHIGENHFILES = m68kops.h

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXENAME          = emulator
 
-MAINFILES        = emulator.c Gayle.c ide.c memory_mapped.c config_file/config_file.c registers/registers_amiga.c
+MAINFILES        = emulator.c Gayle.c ide.c memory_mapped.c config_file/config_file.c registers/registers_amiga.c input/input.c
 MUSASHIFILES     = m68kcpu.c softfloat/softfloat.c 
 MUSASHIGENCFILES = m68kops.c
 MUSASHIGENHFILES = m68kops.h

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -1,0 +1,380 @@
+#include "config_file.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define M68K_CPU_TYPES M68K_CPU_TYPE_SCC68070
+
+const char *cpu_types[M68K_CPU_TYPES] = {
+  "68000",
+  "68010",
+  "68EC020",
+  "68020",
+  "68EC030",
+  "68030",
+  "68EC040",
+  "68LC040",
+  "68040",
+  "SCC68070",
+};
+
+const char *map_type_names[MAPTYPE_NUM] = {
+  "NONE",
+  "rom",
+  "ram",
+  "register",
+};
+
+const char *config_item_names[CONFITEM_NUM] = {
+  "NONE",
+  "cpu",
+  "map",
+  "loopcycles",
+  "mouse",
+  "keyboard",
+};
+
+const char *mapcmd_names[MAPCMD_NUM] = {
+  "NONE",
+  "type",
+  "address",
+  "size",
+  "range",
+  "file",
+  "ovl",
+  "id",
+};
+
+int get_config_item_type(char *cmd) {
+  for (int i = 0; i < CONFITEM_NUM; i++) {
+    if (strcmp(cmd, config_item_names[i]) == 0) {
+      return i;
+    }
+  }
+
+  return CONFITEM_NONE;
+}
+
+unsigned int get_m68k_cpu_type(char *name) {
+  for (int i = 0; i < M68K_CPU_TYPES; i++) {
+    if (strcmp(name, cpu_types[i]) == 0) {
+      printf("Set CPU type to %s.\n", cpu_types[i]);
+      return i + 1;
+    }
+  }
+
+  printf ("Invalid CPU type %s specified, defaulting to 68000.\n", name);
+  return M68K_CPU_TYPE_68000;
+}
+
+unsigned int get_map_cmd(char *name) {
+  for (int i = 1; i < MAPCMD_NUM; i++) {
+    if (strcmp(name, mapcmd_names[i]) == 0) {
+      return i;
+    }
+  }
+
+  return MAPCMD_UNKNOWN;
+}
+
+unsigned int get_map_type(char *name) {
+  for (int i = 1; i < MAPTYPE_NUM; i++) {
+    if (strcmp(name, map_type_names[i]) == 0) {
+      return i;
+    }
+  }
+
+  return MAPTYPE_NONE;
+}
+
+void trim_whitespace(char *str) {
+  while (strlen(str) != 0 && (str[strlen(str) - 1] == ' ' || str[strlen(str) - 1] == '\t' || str[strlen(str) - 1] == 0x0A || str[strlen(str) - 1] == 0x0D)) {
+    str[strlen(str) - 1] = '\0';
+  }
+}
+
+unsigned int get_int(char *str) {
+  if (strlen(str) == 0)
+    return -1;
+
+  int ret_int = 0;
+
+  if (strlen(str) > 2 && str[0] == '0' && str[1] == 'x') {
+    for (int i = 2; i < (int)strlen(str); i++) {
+      if (str[i] >= '0' && str[i] <= '9') {
+        ret_int = (str[i] - '0') | (ret_int << 4);
+      }
+      else {
+        switch(str[i]) {
+          case 'A': ret_int = 0xA | (ret_int << 4); break;
+          case 'B': ret_int = 0xB | (ret_int << 4); break;
+          case 'C': ret_int = 0xC | (ret_int << 4); break;
+          case 'D': ret_int = 0xD | (ret_int << 4); break;
+          case 'E': ret_int = 0xE | (ret_int << 4); break;
+          case 'F': ret_int = 0xF | (ret_int << 4); break;
+          case 'K': ret_int = ret_int * SIZE_KILO; break;
+          case 'M': ret_int = ret_int * SIZE_MEGA; break;
+          case 'G': ret_int = ret_int * SIZE_GIGA; break;
+          default:
+            printf("Unknown character %c in hex value.\n", str[i]);
+            break;
+        }
+      }
+    }
+    return ret_int;
+  }
+  else {
+    ret_int = atoi(str);
+    if (str[strlen(str) - 1] == 'K')
+      ret_int = ret_int * SIZE_KILO;
+    else if (str[strlen(str) - 1] == 'M')
+      ret_int = ret_int * SIZE_MEGA;
+    else if (str[strlen(str) - 1] == 'G')
+      ret_int = ret_int * SIZE_GIGA;
+
+    return ret_int;
+  }
+}
+
+void get_next_string(char *str, char *str_out, int *strpos, char separator) {
+  int str_pos = 0, out_pos = 0;
+
+  if (!str_out)
+    return;
+
+  if (strpos)
+    str_pos = *strpos;
+
+  while (str[str_pos] == ' ' && str[str_pos] == '\t' && str_pos < (int)strlen(str)) {
+    str_pos++;
+  }
+
+  for (int i = str_pos; i < (int)strlen(str); i++) {
+    str_out[out_pos] = str[i];
+    if ((separator == ' ' && (str[i] == ' ' || str[i] == '\t')) || str[i] == separator) {
+      str_out[out_pos] = '\0';
+      if (strpos) {
+        *strpos = i + 1;
+      }
+      break;
+    }
+    out_pos++;
+    if (i + 1 == (int)strlen(str) && strpos) {
+      *strpos = i + 1;
+      str_out[out_pos] = '\0';
+    }
+  }
+}
+
+void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int addr, unsigned int size, int mirr_addr, char *filename, char *map_id) {
+  unsigned int index = 0, file_size = 0;
+  FILE *in = NULL;
+
+  while (index < MAX_NUM_MAPPED_ITEMS) {
+    if (cfg->map_type[index] == MAPTYPE_NONE)
+      break;
+    index++;
+  }
+  if (index == MAX_NUM_MAPPED_ITEMS) {
+    printf("Unable to map item, only %d items can be mapped with current binary.\n", MAX_NUM_MAPPED_ITEMS);
+    return;
+  }
+
+  cfg->map_type[index] = type;
+  cfg->map_offset[index] = addr;
+  cfg->map_size[index] = size;
+  cfg->map_mirror[index] = mirr_addr;
+  if (strlen(map_id)) {
+    cfg->map_id[index] = (char *)malloc(strlen(map_id) + 1);
+    strcpy(cfg->map_id[index], map_id);
+  }
+
+  switch(type) {
+    case MAPTYPE_RAM:
+      printf("Allocating %d bytes for RAM mapping (%d MB)...\n", size, size / 1024 / 1024);
+      cfg->map_data[index] = (unsigned char *)malloc(size);
+      if (!cfg->map_data[index]) {
+        printf("ERROR: Unable to allocate memory for mapped RAM!\n");
+        goto mapping_failed;
+      }
+      memset(cfg->map_data[index], 0x00, size);
+      break;
+    case MAPTYPE_ROM:
+      in = fopen(filename, "rb");
+      if (!in) {
+        printf("Failed to open file %s for ROM mapping.\n", filename);
+        goto mapping_failed;
+      }
+      fseek(in, 0, SEEK_END);
+      file_size = (int)ftell(in);
+      if (size == 0) {
+        cfg->map_size[index] = file_size;
+      }
+      fseek(in, 0, SEEK_SET);
+      cfg->map_data[index] = (unsigned char *)calloc(1, cfg->map_size[index]);
+      if (!cfg->map_data[index]) {
+        printf("ERROR: Unable to allocate memory for mapped ROM!\n");
+        goto mapping_failed;
+      }
+      memset(cfg->map_data[index], 0x00, cfg->map_size[index]);
+      fread(cfg->map_data[index], (cfg->map_size[index] <= file_size) ? cfg->map_size[index] : file_size, 1, in);
+      fclose(in);
+      break;
+    case MAPTYPE_REGISTER:
+    default:
+      break;
+      break;
+  }
+
+  printf("[MAP %d] Added %s mapping for range %.8lX-%.8lX (%.8lX)\n", index, map_type_names[type], cfg->map_offset[index], cfg->map_offset[index] + cfg->map_size[index] - 1, (uint64_t)cfg->map_data[index]);
+
+  return;
+
+  mapping_failed:;
+  cfg->map_type[index] = MAPTYPE_NONE;
+  if (in)
+    fclose(in);
+}
+
+struct emulator_config *load_config_file(char *filename) {
+  FILE *in = fopen(filename, "rb");
+  if (in == NULL) {
+    printf("Failed to open config file %s for reading.\n", filename);
+    return NULL;
+  }
+
+  char *parse_line = NULL;
+  char cur_cmd[128];
+  struct emulator_config *cfg = NULL;
+  int cur_line = 1;
+
+  parse_line = (char *)calloc(1, 512);
+  if (!parse_line) {
+    printf("Failed to allocate memory for config file line buffer.\n");
+    return NULL;
+  }
+  cfg = (struct emulator_config *)calloc(1, sizeof(struct emulator_config));
+  if (!cfg) {
+    printf("Failed to allocate memory for temporary emulator config.\n");
+    goto load_failed;
+  }
+
+  memset(cfg, 0x00, sizeof(struct emulator_config));
+  cfg->cpu_type = M68K_CPU_TYPE_68000;
+
+  while (!feof(in)) {
+    int str_pos = 0;
+    memset(parse_line, 0x00, 512);
+    fgets(parse_line, 512, in);
+
+    if (strlen(parse_line) <= 2 || parse_line[0] == '#' || parse_line[0] == '/')
+      goto skip_line;
+
+    trim_whitespace(parse_line);
+    
+    get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+
+    switch (get_config_item_type(cur_cmd)) {
+      case CONFITEM_CPUTYPE:
+        cfg->cpu_type = get_m68k_cpu_type(parse_line + str_pos);
+        break;
+      case CONFITEM_MAP: {
+        unsigned int maptype = 0, mapsize = 0, mapaddr = 0;
+        int mirraddr = -1;
+        char mapfile[128], mapid[128];
+        memset(mapfile, 0x00, 128);
+        memset(mapid, 0x00, 128);
+
+        while (str_pos < (int)strlen(parse_line)) {
+          get_next_string(parse_line, cur_cmd, &str_pos, '=');
+          switch(get_map_cmd(cur_cmd)) {
+            case MAPCMD_TYPE:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              maptype = get_map_type(cur_cmd);
+              //printf("Type! %s\n", map_type_names[maptype]);
+              break;
+            case MAPCMD_ADDRESS:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              mapaddr = get_int(cur_cmd);
+              //printf("Address! %.8X\n", mapaddr);
+              break;
+            case MAPCMD_SIZE:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              mapsize = get_int(cur_cmd);
+              //printf("Size! %.8X\n", mapsize);
+              break;
+            case MAPCMD_RANGE:
+              get_next_string(parse_line, cur_cmd, &str_pos, '-');
+              mapaddr = get_int(cur_cmd);
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              mapsize = get_int(cur_cmd) - 1 - mapaddr;
+              //printf("Range! %d-%d\n", mapaddr, mapaddr + mapsize);
+              break;
+            case MAPCMD_FILENAME:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              strcpy(mapfile, cur_cmd);
+              //printf("File! %s\n", mapfile);
+              break;
+            case MAPCMD_MAP_ID:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              strcpy(mapid, cur_cmd);
+              //printf("File! %s\n", mapfile);
+              break;
+            case MAPCMD_OVL_REMAP:
+              get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+              mirraddr = get_int(cur_cmd);
+              break;
+            default:
+              printf("Unknown/unhandled map argument %s on line %d.\n", cur_cmd, cur_line);
+              break;
+          }
+        }
+        add_mapping(cfg, maptype, mapaddr, mapsize, mirraddr, mapfile, mapid);
+
+        break;
+      }
+      case CONFITEM_LOOPCYCLES:
+        cfg->loop_cycles = get_int(parse_line + str_pos);
+        printf("Set CPU loop cycles to %d.\n", cfg->loop_cycles);
+        break;
+      case CONFITEM_MOUSE:
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->mouse_file = (char *)calloc(1, strlen(cur_cmd) + 1);
+        strcpy(cfg->mouse_file, cur_cmd);
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->mouse_toggle_key = cur_cmd[0];
+        cfg->mouse_enabled = 1;
+        printf("Enabled mouse event forwarding from file %s, toggle key %c.\n", cfg->mouse_file, cfg->mouse_toggle_key);
+        break;
+      case CONFITEM_KEYBOARD:
+        get_next_string(parse_line, cur_cmd, &str_pos, ' ');
+        cfg->keyboard_toggle_key = cur_cmd[0];
+        printf("Enabled keyboard event forwarding, toggle key %c.\n", cfg->keyboard_toggle_key);
+        break;
+      case CONFITEM_NONE:
+      default:
+        printf("Unknown config item %s on line %d.\n", cur_cmd, cur_line);
+        break;
+    }
+    
+    skip_line:;
+    cur_line++;
+  }
+  goto load_successful;
+
+  load_failed:;
+  if (cfg) {
+    for (int i = 0; i < MAX_NUM_MAPPED_ITEMS; i++) {
+      if (cfg->map_data[i])
+        free(cfg->map_data[i]);
+      cfg->map_data[i] = NULL;
+    }
+    free(cfg);
+    cfg = NULL;
+  }
+  load_successful:;
+  if (parse_line)
+    free(parse_line);
+
+  return cfg;
+}

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -226,7 +226,7 @@ void add_mapping(struct emulator_config *cfg, unsigned int type, unsigned int ad
       break;
   }
 
-  printf("[MAP %d] Added %s mapping for range %.8lX-%.8lX (%.8lX)\n", index, map_type_names[type], cfg->map_offset[index], cfg->map_offset[index] + cfg->map_size[index] - 1, (uint64_t)cfg->map_data[index]);
+  printf("[MAP %d] Added %s mapping for range %.8lX-%.8lX (%lX)\n", index, map_type_names[type], cfg->map_offset[index], cfg->map_offset[index] + cfg->map_size[index] - 1, (uint64_t)cfg->map_data[index]);
 
   return;
 

--- a/config_file/config_file.h
+++ b/config_file/config_file.h
@@ -1,0 +1,72 @@
+#include "../m68k.h"
+
+#define MAX_NUM_MAPPED_ITEMS 8
+#define SIZE_KILO 1024
+#define SIZE_MEGA (1024 * 1024)
+#define SIZE_GIGA (1024 * 1024 * 1024)
+
+typedef enum {
+  MAPTYPE_NONE,
+  MAPTYPE_ROM,
+  MAPTYPE_RAM,
+  MAPTYPE_REGISTER,
+  MAPTYPE_NUM,
+} map_types;
+
+typedef enum {
+  MAPCMD_UNKNOWN,
+  MAPCMD_TYPE,
+  MAPCMD_ADDRESS,
+  MAPCMD_SIZE,
+  MAPCMD_RANGE,
+  MAPCMD_FILENAME,
+  MAPCMD_OVL_REMAP,
+  MAPCMD_MAP_ID,
+  MAPCMD_NUM,
+} map_cmds;
+
+typedef enum {
+  CONFITEM_NONE,
+  CONFITEM_CPUTYPE,
+  CONFITEM_MAP,
+  CONFITEM_LOOPCYCLES,
+  CONFITEM_MOUSE,
+  CONFITEM_KEYBOARD,
+  CONFITEM_NUM,
+} config_items;
+
+typedef enum {
+  OP_TYPE_BYTE,
+  OP_TYPE_WORD,
+  OP_TYPE_LONGWORD,
+  OP_TYPE_MEM,
+  OP_TYPE_NUM,
+} map_op_types;
+
+struct emulator_config {
+  unsigned int cpu_type;
+
+  unsigned char map_type[MAX_NUM_MAPPED_ITEMS];
+  long map_offset[MAX_NUM_MAPPED_ITEMS];
+  unsigned int map_size[MAX_NUM_MAPPED_ITEMS];
+  unsigned char *map_data[MAX_NUM_MAPPED_ITEMS];
+  int map_mirror[MAX_NUM_MAPPED_ITEMS];
+  char *map_id[MAX_NUM_MAPPED_ITEMS];
+
+  char *mouse_file;
+
+  char mouse_toggle_key, keyboard_toggle_key;
+  unsigned char mouse_enabled, keyboard_enabled;
+
+  unsigned int loop_cycles;
+};
+
+unsigned int get_m68k_cpu_type(char *name);
+struct emulator_config *load_config_file(char *filename);
+
+int handle_mapped_read(struct emulator_config *cfg, unsigned int addr, unsigned int *val, unsigned char type, unsigned char mirror);
+int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned int value, unsigned char type, unsigned char mirror);
+int handle_register_read(unsigned int addr, unsigned char type, unsigned int *val);
+int handle_register_write(unsigned int addr, unsigned int value, unsigned char type);
+
+int get_mouse_status(char *x, char *y, char *b);

--- a/config_file/config_file.h
+++ b/config_file/config_file.h
@@ -68,5 +68,3 @@ int handle_mapped_read(struct emulator_config *cfg, unsigned int addr, unsigned 
 int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned int value, unsigned char type, unsigned char mirror);
 int handle_register_read(unsigned int addr, unsigned char type, unsigned int *val);
 int handle_register_write(unsigned int addr, unsigned int value, unsigned char type);
-
-int get_mouse_status(char *x, char *y, char *b);

--- a/default.cfg
+++ b/default.cfg
@@ -1,0 +1,19 @@
+# Sets CPU type. Valid types are (probably) 68000, 68010, 68020, 68EC020, 68030, 68EC030, 68040, 68EC040, 68LC040 and some STTTT thing.
+cpu 68EC030
+# Map 512KB kickstart ROM to default offset.
+map type=rom address=0xF80000 size=0x80000 file=kick512.rom ovl=0
+# This is for mapping a 256KB kickstart ROM. I can probably add some additional thing about kicking this file into low/high area.
+#map type=rom address=0xFC0000 size=0x40000 file=kick256.rom ovl=0
+# Want to map an extended ROM, such as CDTV or CD32?
+#map type=rom address=0xF00000 size=0x90000 file=cdtv.rom
+# Map 256MB of Fast RAM at 0x8000000.
+map type=ram address=0x08000000 size=128M
+# Map Gayle as a register range.
+map type=register address=0xD80000 size=0x70000
+# Number of instructions to run every main loop.
+loopcycles 300
+# Forward mouse events to host system, defaults to off unless toggle key is pressed on the Pi.
+# Syntax is mouse [device] [toggle key]
+#mouse /dev/input/mouse0 m
+# Forward keyboard events to host system, defaults to off unless toggle key is pressed, toggled off using F12.
+#keyboard k

--- a/default.cfg
+++ b/default.cfg
@@ -8,7 +8,6 @@ map type=rom address=0xF80000 size=0x80000 file=kick512.rom ovl=0
 #map type=rom address=0xF00000 size=0x90000 file=cdtv.rom
 # Map 256MB of Fast RAM at 0x8000000.
 map type=ram address=0x08000000 size=128M
-map type=ram address=0x0 size=2M
 # Map Gayle as a register range.
 map type=register address=0xD80000 size=0x70000
 # Number of instructions to run every main loop.

--- a/default.cfg
+++ b/default.cfg
@@ -1,5 +1,5 @@
 # Sets CPU type. Valid types are (probably) 68000, 68010, 68020, 68EC020, 68030, 68EC030, 68040, 68EC040, 68LC040 and some STTTT thing.
-cpu 68EC030
+cpu 68020
 # Map 512KB kickstart ROM to default offset.
 map type=rom address=0xF80000 size=0x80000 file=kick512.rom ovl=0
 # This is for mapping a 256KB kickstart ROM. I can probably add some additional thing about kicking this file into low/high area.
@@ -8,6 +8,7 @@ map type=rom address=0xF80000 size=0x80000 file=kick512.rom ovl=0
 #map type=rom address=0xF00000 size=0x90000 file=cdtv.rom
 # Map 256MB of Fast RAM at 0x8000000.
 map type=ram address=0x08000000 size=128M
+map type=ram address=0x0 size=2M
 # Map Gayle as a register range.
 map type=register address=0xD80000 size=0x70000
 # Number of instructions to run every main loop.

--- a/emulator.c
+++ b/emulator.c
@@ -153,10 +153,17 @@ static volatile unsigned char ovl;
 static volatile unsigned char maprom;
 
 void sigint_handler(int sig_num) {
-  if (sig_num) { }
-  cpu_emulation_running = 0;
+  //if (sig_num) { }
+  //cpu_emulation_running = 0;
 
-  return;
+  //return;
+  printf("Received sigint %d, exiting.\n", sig_num);
+  if (mouse_fd != -1)
+    close(mouse_fd);
+  if (mem_fd)
+    close(mem_fd);
+
+  exit(0);
 }
 
 void *iplThread(void *args) {
@@ -354,7 +361,7 @@ int main(int argc, char *argv[]) {
     if (cpu_emulation_running)
       m68k_execute(loop_cycles);
     
-    while (kbhit()) {
+    /*while (kbhit()) {
       char c = getchar();
       if (c == cfg->keyboard_toggle_key && !kb_hook_enabled) {
         kb_hook_enabled = 1;
@@ -382,7 +389,7 @@ int main(int argc, char *argv[]) {
         printf("Quitting and exiting emulator.\n");
         goto stop_cpu_emulation;
       }
-    }
+    }*/
 /*
     if (toggle == 1){
       srdata = read_reg();

--- a/emulator.c
+++ b/emulator.c
@@ -361,6 +361,7 @@ int main(int argc, char *argv[]) {
     if (cpu_emulation_running)
       m68k_execute(loop_cycles);
     
+    // FIXME: Rework this to use keyboard events instead.
     /*while (kbhit()) {
       char c = getchar();
       if (c == cfg->keyboard_toggle_key && !kb_hook_enabled) {

--- a/emulator.c
+++ b/emulator.c
@@ -170,12 +170,10 @@ static volatile unsigned char ovl;
 static volatile unsigned char maprom;
 
 void sigint_handler(int sig_num) {
-  printf("\n Exit Ctrl+C %d\n", sig_num);
-  if (mouse_fd != -1)
-    close(mouse_fd);
-  if (mem_fd)
-    close(mem_fd);
-  exit(0);
+  if (sig_num) { }
+  cpu_emulation_running = 0;
+
+  return;
 }
 
 void *iplThread(void *args) {
@@ -413,6 +411,15 @@ int main(int argc, char *argv[]) {
         cpu_emulation_running ^= 1;
         printf("CPU emulation is now %s\n", cpu_emulation_running ? "running" : "stopped");
       }
+      if (c == 'R') {
+        cpu_pulse_reset();
+        m68k_pulse_reset();
+        printf("CPU emulation reset.\n");
+      }
+      if (c == 'q') {
+        printf("Quitting and exiting emulator.\n");
+        goto stop_cpu_emulation;
+      }
     }
 /*
     if (toggle == 1){
@@ -425,18 +432,26 @@ int main(int argc, char *argv[]) {
 */
 
 
-    if (GET_GPIO(1) == 0){
+    if (GET_GPIO(1) == 0) {
       srdata = read_reg();
       m68k_set_irq((srdata >> 13) & 0xff);
     } else {
-      if (CheckIrq() == 1){
+      if (CheckIrq() == 1) {
         write16(0xdff09c, 0x8008);
-        m68k_set_irq(2);}
+        m68k_set_irq(2);
+      }
       else
          m68k_set_irq(0);
     };
 
   }
+
+  stop_cpu_emulation:;
+
+  if (mouse_fd != -1)
+    close(mouse_fd);
+  if (mem_fd)
+    close(mem_fd);
 
   return 0;
 }

--- a/input/input.c
+++ b/input/input.c
@@ -1,0 +1,34 @@
+#include <termios.h>
+#include <unistd.h>
+#include <linux/input.h>
+
+int kbhit()
+{
+  struct termios term;
+  tcgetattr(0, &term);
+
+  struct termios term2 = term;
+  term2.c_lflag &= ~ICANON;
+  tcsetattr(0, TCSANOW, &term2);
+
+  int byteswaiting;
+  ioctl(0, FIONREAD, &byteswaiting);
+
+  tcsetattr(0, TCSANOW, &term);
+
+  return byteswaiting > 0;
+}
+
+extern int mouse_fd;
+
+int get_mouse_status(char *x, char *y, char *b) {
+  struct input_event ie;
+  if (read(mouse_fd, &ie, sizeof(struct input_event)) != -1) {
+    *b = ((char *)&ie)[0];
+    *x = ((char *)&ie)[1];
+    *y = ((char *)&ie)[2];
+    return 1;
+  }
+
+  return 0;
+}

--- a/input/input.c
+++ b/input/input.c
@@ -4,19 +4,7 @@
 
 int kbhit()
 {
-  struct termios term;
-  tcgetattr(0, &term);
-
-  struct termios term2 = term;
-  term2.c_lflag &= ~ICANON;
-  tcsetattr(0, TCSANOW, &term2);
-
-  int byteswaiting;
-  ioctl(0, FIONREAD, &byteswaiting);
-
-  tcsetattr(0, TCSANOW, &term);
-
-  return byteswaiting > 0;
+  return 0;
 }
 
 extern int mouse_fd;

--- a/input/input.h
+++ b/input/input.h
@@ -1,0 +1,2 @@
+int get_mouse_status(char *x, char *y, char *b);
+int kbhit();

--- a/memory_mapped.c
+++ b/memory_mapped.c
@@ -1,4 +1,5 @@
 #include "config_file/config_file.h"
+#include "m68k.h"
 #include "Gayle.h"
 #include <endian.h>
 
@@ -51,7 +52,7 @@ int handle_mapped_read(struct emulator_config *cfg, unsigned int addr, unsigned 
       return -1;
     }
     else if (read_addr) {
-      //printf("Read %s from %s (%.8X) (%d)\n", op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
+      //printf("[PC: %.8X] Read %s from %s (%.8X) (%d)\n", m68k_get_reg(NULL, M68K_REG_PC), op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
       //printf("Readaddr: %.8lX (Base %.8lX\n", (uint64_t)(read_addr), (uint64_t)cfg->map_data[i]);
       switch(type) {
         case OP_TYPE_BYTE:
@@ -84,15 +85,14 @@ int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned
   char handle_regs = 0;
 
   //printf("Mapped write: %.8x\n", addr);
+  if (mirror) { }
 
   for (int i = 0; i < MAX_NUM_MAPPED_ITEMS; i++) {
     if (cfg->map_type[i] == MAPTYPE_NONE)
       continue;
     switch(cfg->map_type[i]) {
       case MAPTYPE_ROM:
-        if (cfg->map_mirror[i] != -1 && mirror && CHKRANGE(addr, cfg->map_mirror[i], cfg->map_size[i]))
-          return -1;
-        else if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
           return 1;
         break;
       case MAPTYPE_RAM:
@@ -112,7 +112,7 @@ int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned
       return handle_register_write(addr, value, type);
     }
     else if (write_addr) {
-      //printf("Write %s to %s (%.8X) (%d)\n", op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
+      //printf("[PC: %.8X] Write %s to %s (%.8X) (%d)\n", m68k_get_reg(NULL, M68K_REG_PC), op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
       //printf("Writeaddr: %.8lX (Base %.8lX\n", (uint64_t)(write_addr), (uint64_t)cfg->map_data[i]);
       switch(type) {
         case OP_TYPE_BYTE:

--- a/memory_mapped.c
+++ b/memory_mapped.c
@@ -1,0 +1,141 @@
+#include "config_file/config_file.h"
+#include "Gayle.h"
+#include <endian.h>
+
+#define CHKRANGE(a, b, c) a >= (unsigned int)b && a < (unsigned int)(b + c)
+
+static unsigned int target;
+
+extern const char *map_type_names[MAPTYPE_NUM];
+const char *op_type_names[OP_TYPE_NUM] = {
+  "BYTE",
+  "WORD",
+  "LONGWORD",
+  "MEM",
+};
+
+int handle_mapped_read(struct emulator_config *cfg, unsigned int addr, unsigned int *val, unsigned char type, unsigned char mirror) {
+  unsigned char *read_addr = NULL;
+  char handle_regs = 0;
+
+  //printf("Mapped read: %.8x\n", addr);
+
+  for (int i = 0; i < MAX_NUM_MAPPED_ITEMS; i++) {
+    if (cfg->map_type[i] == MAPTYPE_NONE)
+      continue;
+    switch(cfg->map_type[i]) {
+      case MAPTYPE_ROM:
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          read_addr = cfg->map_data[i] + (addr - cfg->map_offset[i]);
+        else if (cfg->map_mirror[i] != -1 && mirror && CHKRANGE(addr, cfg->map_mirror[i], cfg->map_size[i]))
+          read_addr = cfg->map_data[i] + (addr - cfg->map_mirror[i]);
+        break;
+      case MAPTYPE_RAM:
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          read_addr = cfg->map_data[i] + (addr - cfg->map_offset[i]);
+        break;
+      case MAPTYPE_REGISTER:
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          handle_regs = 1;
+        break;
+    }
+
+    if (!read_addr && !handle_regs)
+      continue;
+    
+    if (handle_regs) {
+      if (handle_register_read(addr, type, &target) != -1) {
+        *val = target;
+        return 1;
+      }
+      return -1;
+    }
+    else if (read_addr) {
+      //printf("Read %s from %s (%.8X) (%d)\n", op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
+      //printf("Readaddr: %.8lX (Base %.8lX\n", (uint64_t)(read_addr), (uint64_t)cfg->map_data[i]);
+      switch(type) {
+        case OP_TYPE_BYTE:
+          *val = read_addr[0];
+          //printf("Read val: %.8lX (%d)\n", (uint64_t)val, *val);
+          return 1;
+          break;
+        case OP_TYPE_WORD:
+          *val = be16toh(((unsigned short *)read_addr)[0]);
+          //printf("Read val: %.8lX (%d)\n", (uint64_t)val, *val);
+          return 1;
+          break;
+        case OP_TYPE_LONGWORD:
+          *val = be32toh(((unsigned int *)read_addr)[0]);
+          //printf("Read val: %.8lX (%d)\n", (uint64_t)val, *val);
+          return 1;
+          break;
+        case OP_TYPE_MEM:
+          return -1;
+          break;
+      }
+    }
+  }
+
+  return -1;
+}
+
+int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned int value, unsigned char type, unsigned char mirror) {
+  unsigned char *write_addr = NULL;
+  char handle_regs = 0;
+
+  //printf("Mapped write: %.8x\n", addr);
+
+  for (int i = 0; i < MAX_NUM_MAPPED_ITEMS; i++) {
+    if (cfg->map_type[i] == MAPTYPE_NONE)
+      continue;
+    switch(cfg->map_type[i]) {
+      case MAPTYPE_ROM:
+        if (cfg->map_mirror[i] != -1 && mirror && CHKRANGE(addr, cfg->map_mirror[i], cfg->map_size[i]))
+          return -1;
+        else if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          return 1;
+        break;
+      case MAPTYPE_RAM:
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          write_addr = cfg->map_data[i] + (addr - cfg->map_offset[i]);
+        break;
+      case MAPTYPE_REGISTER:
+        if (CHKRANGE(addr, cfg->map_offset[i], cfg->map_size[i]))
+          handle_regs = 1;
+        break;
+    }
+
+    if (!write_addr && !handle_regs)
+      continue;
+    
+    if (handle_regs) {
+      return handle_register_write(addr, value, type);
+    }
+    else if (write_addr) {
+      //printf("Write %s to %s (%.8X) (%d)\n", op_type_names[type], map_type_names[cfg->map_type[i]], addr, mirror);
+      //printf("Writeaddr: %.8lX (Base %.8lX\n", (uint64_t)(write_addr), (uint64_t)cfg->map_data[i]);
+      switch(type) {
+        case OP_TYPE_BYTE:
+          write_addr[0] = (unsigned char)value;
+          //printf("Write val: %.8X (%d)\n", (uint32_t)value, value);
+          return 1;
+          break;
+        case OP_TYPE_WORD:
+          ((short *)write_addr)[0] = htobe16(value);
+          //printf("Write val: %.8X (%d)\n", (uint32_t)value, value);
+          return 1;
+          break;
+        case OP_TYPE_LONGWORD:
+          ((int *)write_addr)[0] = htobe32(value);
+          //printf("Write val: %.8X (%d)\n", (uint32_t)value, value);
+          return 1;
+          break;
+        case OP_TYPE_MEM:
+          return -1;
+          break;
+      }
+    }
+  }
+
+  return -1;
+}

--- a/registers/registers_amiga.c
+++ b/registers/registers_amiga.c
@@ -1,0 +1,51 @@
+#include "../Gayle.h"
+#include "../config_file/config_file.h"
+
+#define GAYLEBASE 0xD80000  // D7FFFF
+#define GAYLESIZE 0x6FFFF
+
+int handle_register_read(unsigned int addr, unsigned char type, unsigned int *val) {
+    if (addr > GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
+        switch(type) {
+        case OP_TYPE_BYTE:
+            *val = readGayleB(addr);
+            return 1;
+            break;
+        case OP_TYPE_WORD:
+            *val = readGayle(addr);
+            return 1;
+            break;
+        case OP_TYPE_LONGWORD:
+            *val = readGayleL(addr);
+            return 1;
+            break;
+        case OP_TYPE_MEM:
+            return -1;
+            break;
+        }
+    }
+    return -1;
+}
+
+int handle_register_write(unsigned int addr, unsigned int value, unsigned char type) {
+    if (addr > GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
+        switch(type) {
+        case OP_TYPE_BYTE:
+            writeGayleB(addr, value);
+            return 1;
+            break;
+        case OP_TYPE_WORD:
+            writeGayle(addr, value);
+            return 1;
+            break;
+        case OP_TYPE_LONGWORD:
+            writeGayleL(addr, value);
+            return 1;
+            break;
+        case OP_TYPE_MEM:
+            return -1;
+            break;
+        }
+    }
+    return -1;
+}

--- a/registers/registers_dummy.c
+++ b/registers/registers_dummy.c
@@ -1,0 +1,7 @@
+int handle_register_read(unsigned int addr, unsigned char type) {
+    return -1;
+}
+
+int handle_register_write(unsigned int addr, unsigned char type) {
+    return -1;
+}

--- a/test.cfg
+++ b/test.cfg
@@ -1,0 +1,11 @@
+cpu 68000
+#map type=rom address=0xF80000 size=0x80000 file=kick512.rom ovl=0
+#map type=rom address=0xF00000 size=0x90000 file=cdtv.rom
+# Map 256MB of Fast RAM at 0x8000000.
+#map type=ram address=0x08000000 size=256M
+# Map Gayle as a register range.
+#map type=register address=0xD80000 size=0x70000
+# Number of instructions to run every main loop.
+loopcycles 300
+mouse /dev/input/mouse0 m
+keyboard k

--- a/x68k.cfg
+++ b/x68k.cfg
@@ -1,0 +1,17 @@
+# Sets CPU type. Valid types are (probably) 68000, 68010, 68020, 68EC020, 68030, 68EC030, 68040, 68EC040, 68LC040 and some STTTT thing.
+cpu 68000
+
+# Various ROM locations
+#map type=rom address=0xF00000 file=cgrom
+#map type=rom address=0xFC0000 file=scsiin
+#map type=rom address=0xFE0000 file=ipl
+
+# 10MB of expanded RAM, for machines with 2MB internal.
+map type=ram address=2M size=10M
+# 11MB of expanded RAM, for machines with 1MB internal.
+#map type=ram address=1M size=11M
+
+# Map Gayle as a register range.
+#map type=register address=0xD80000 size=0x70000
+# Number of instructions to run every main loop.
+loopcycles 60

--- a/x68k.cfg
+++ b/x68k.cfg
@@ -4,7 +4,7 @@ cpu 68000
 # Various ROM locations
 #map type=rom address=0xF00000 file=cgrom
 #map type=rom address=0xFC0000 file=scsiin
-#map type=rom address=0xFE0000 file=ipl
+#map type=rom address=0xFE0000 file=ipl ovl=0
 
 # 10MB of expanded RAM, for machines with 2MB internal.
 map type=ram address=2M size=10M


### PR DESCRIPTION
Adds basic config file support for setting up custom mapped memory ranges for RAM, ROM and registers, set the CPU type and set up input device forwarding.
Keyboard input is currently disabled due to performance reasons, but can be enabled later to pause/reset emulation and forward keyboard events to the host system