### PR TITLE
Add setvar to Amiga platform for RTC and HDD0 image configuration

### DIFF
--- a/Gayle.c
+++ b/Gayle.c
@@ -13,11 +13,10 @@
 #include "Gayle.h"
 #include <fcntl.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include "ide.h"
-
-#define CLOCKBASE 0xDC0000
 
 //#define GSTATUS 0xda201c
 //#define GCLOW   0xda2010
@@ -87,20 +86,36 @@
 #define GAYLE_INT_BVD_LEV 0x02 /* BVD int level, 0=lev2,1=lev6 */
 #define GAYLE_INT_BSY_LEV 0x01 /* BSY int level, 0=lev2,1=lev6 */
 
+#define GAYLE_MAX_HARDFILES 8
+
 int counter;
 static uint8_t gayle_irq, gayle_int, gayle_cs, gayle_cs_mask, gayle_cfg;
 static struct ide_controller *ide0;
 int fd;
 
+char *hdd_image_file[GAYLE_MAX_HARDFILES];
+
+void set_hard_drive_image_file_amiga(uint8_t index, char *filename) {
+  if (hdd_image_file[index] != NULL)
+    free(hdd_image_file[index]);
+  hdd_image_file[index] = calloc(1, strlen(filename) + 1);
+  strcpy(hdd_image_file[index], filename);
+}
+
 void InitGayle(void) {
+  if (!hdd_image_file[0]) {
+    hdd_image_file[0] = calloc(1, 64);
+    sprintf(hdd_image_file[0], "hd0.img");
+  }
+
   ide0 = ide_allocate("cf");
-  fd = open("hd0.img", O_RDWR);
+  fd = open(hdd_image_file[0], O_RDWR);
   if (fd == -1) {
-    printf("HDD Image hd0.image failed open\n");
+    printf("HDD Image %s failed open\n", hdd_image_file[0]);
   } else {
     ide_attach(ide0, 0, fd);
     ide_reset_begin(ide0);
-    printf("HDD Image hd0.image attached\n");
+    printf("HDD Image %s attached\n", hdd_image_file[0]);
   }
 }
 

--- a/config_file/config_file.c
+++ b/config_file/config_file.c
@@ -33,6 +33,7 @@ const char *config_item_names[CONFITEM_NUM] = {
   "mouse",
   "keyboard",
   "platform",
+  "setvar",
 };
 
 const char *mapcmd_names[MAPCMD_NUM] = {
@@ -364,6 +365,21 @@ struct emulator_config *load_config_file(char *filename) {
           printf(" (sub: %s)", platform_sub);
         printf("\n");
         cfg->platform = make_platform_config(platform_name, platform_sub);
+        break;
+      }
+      case CONFITEM_SETVAR: {
+        if (!cfg->platform) {
+          printf("Warning: esetvar used in config file with no platform specified.\n");
+          break;
+        }
+
+        char var_name[128], var_value[128];
+        memset(var_name, 0x00, 128);
+        memset(var_value, 0x00, 128);
+        get_next_string(parse_line, var_name, &str_pos, ' ');
+        get_next_string(parse_line, var_value, &str_pos, ' ');
+        cfg->platform->setvar(var_name, var_value);
+
         break;
       }
       case CONFITEM_NONE:

--- a/config_file/config_file.h
+++ b/config_file/config_file.h
@@ -33,6 +33,7 @@ typedef enum {
   CONFITEM_MOUSE,
   CONFITEM_KEYBOARD,
   CONFITEM_PLATFORM,
+  CONFITEM_SETVAR,
   CONFITEM_NUM,
 } config_items;
 
@@ -84,3 +85,4 @@ struct emulator_config *load_config_file(char *filename);
 int handle_mapped_read(struct emulator_config *cfg, unsigned int addr, unsigned int *val, unsigned char type, unsigned char mirror);
 int handle_mapped_write(struct emulator_config *cfg, unsigned int addr, unsigned int value, unsigned char type, unsigned char mirror);
 int get_named_mapped_item(struct emulator_config *cfg, char *name);
+unsigned int get_int(char *str);

--- a/default.cfg
+++ b/default.cfg
@@ -24,6 +24,10 @@ map type=register address=0xD80000 size=0x70000
 loopcycles 300
 # Set the platform to Amiga to enable all the registers and stuff.
 platform amiga
+# Uncomment to let reads/writes through from/to the RTC memory range
+#setvar enable_rtc_emulation 0
+# Uncomment to set a custom HD image file for ide0
+#setvar hdd0 snakes.img
 
 # Forward mouse events to host system, defaults to off unless toggle key is pressed on the Pi.
 # Syntax is mouse [device] [toggle key]

--- a/platforms/amiga/amiga-platform.c
+++ b/platforms/amiga/amiga-platform.c
@@ -1,8 +1,9 @@
-#include "../platforms.h"
-#include "amiga-autoconf.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../platforms.h"
+#include "amiga-autoconf.h"
+#include "amiga-registers.h"
 
 int handle_register_read_amiga(unsigned int addr, unsigned char type, unsigned int *val);
 int handle_register_write_amiga(unsigned int addr, unsigned int value, unsigned char type);
@@ -165,7 +166,24 @@ int setup_platform_amiga(struct emulator_config *cfg) {
 }
 
 void setvar_amiga(char *var, char *val) {
-    if (var || val) {}
+    if (!var)
+        return;
+
+    if (strcmp(var, "enable_rtc_emulation") == 0) {
+        int8_t rtc_enabled = 0;
+        if (!val || strlen(val) == 0)
+            rtc_enabled = 1;
+        else {
+            rtc_enabled = get_int(val);
+        }
+        if (rtc_enabled != -1) {
+            configure_rtc_emulation_amiga(rtc_enabled);
+        }
+    }
+    if (strcmp(var, "hdd0") == 0) {
+        if (val && strlen(val) != 0)
+            set_hard_drive_image_file_amiga(0, val);
+    }
 }
 
 void create_platform_amiga(struct platform_config *cfg, char *subsys) {

--- a/platforms/amiga/amiga-registers.c
+++ b/platforms/amiga/amiga-registers.c
@@ -4,8 +4,23 @@
 #define GAYLEBASE 0xD80000  // D7FFFF
 #define GAYLESIZE 0x6FFFF
 
+#define CLOCKBASE 0xDC0000
+#define CLOCKSIZE 0x010000
+
+uint8_t rtc_emulation_enabled = 1;
+
+void configure_rtc_emulation_amiga(uint8_t enabled) {
+    if (enabled == rtc_emulation_enabled)
+        return;
+
+    rtc_emulation_enabled = enabled;
+    printf("Amiga RTC emulation is now %s.\n", (enabled) ? "enabled" : "disabled");
+}
+
 int handle_register_read_amiga(unsigned int addr, unsigned char type, unsigned int *val) {
-    if (addr > GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
+    if (!rtc_emulation_enabled && addr >= CLOCKBASE && addr < CLOCKBASE + CLOCKSIZE)
+        return -1;
+    if (addr >= GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
         switch(type) {
         case OP_TYPE_BYTE:
             *val = readGayleB(addr);
@@ -28,7 +43,9 @@ int handle_register_read_amiga(unsigned int addr, unsigned char type, unsigned i
 }
 
 int handle_register_write_amiga(unsigned int addr, unsigned int value, unsigned char type) {
-    if (addr > GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
+    if (!rtc_emulation_enabled && addr >= CLOCKBASE && addr < CLOCKBASE + CLOCKSIZE)
+        return -1;
+    if (addr >= GAYLEBASE && addr < GAYLEBASE + GAYLESIZE) {
         switch(type) {
         case OP_TYPE_BYTE:
             writeGayleB(addr, value);

--- a/platforms/amiga/amiga-registers.h
+++ b/platforms/amiga/amiga-registers.h
@@ -1,0 +1,2 @@
+void configure_rtc_emulation_amiga(uint8_t enabled);
+void set_hard_drive_image_file_amiga(uint8_t index, char *filename);


### PR DESCRIPTION
Adds config file `setvar` implementation to the Amiga platform, for configuring RTC emulation (fallthrough for reads and writes) and changing the Gayle hd0 image file without having to recompile or rename files.