### PR TITLE
Z3 Fast RAM + Readme/config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Join us on Discord or on Freenode IRC #PiStorm 
 
-* There's a Discord server dedicated to the PiStorm, which you can join through this handy invite link: https://discord.com/invite/j6rPtzxaNW
+* There's a Discord server dedicated to PiStorm discussion and development, which you can join through this handy invite link: https://discord.com/invite/j6rPtzxaNW
 * There's also an IRC channel on the Freenode IRC network, `#PiStorm`, which is bridged with the `#general` channel on Discord.
 
 # Project information
@@ -25,7 +25,7 @@ Since much of the initial work and testing for the PiStorm was done on Amiga com
 * Kickstart ROM mapping: 1.3, 2.0, 3.1, anything you might own and have dumped in a byteswapped format. Extended ROM mapping as well for instance with the CDTV extended BIOS.
   * An A1200 3.1+ Kickstart ROM is currently recommended, as this one has the most dynamic automatic configuration on boot.
 * Fast RAM: Z2, Z3 and CPU local Fast can be mapped for high performance memory available to the CPU only on the PiStorm side of things.
-* Virtual SCSI: PiSCSI, a high performance virtual SCSI interface for mapping raw RDB disk images for physical connected to the Pi for use on the Amiga.
+* Virtual SCSI: PiSCSI, a high performance virtual SCSI interface for mapping raw RDB disk images or physical storage devices connected to the Pi for use on the Amiga.
 * RTG: PiGFX, a virtual RTG board with almost all P96-supported functionality supported and accelerated.
 * Some other things: Most likely I forgot something while writing this, but someone will probably tell me about it.
 

--- a/default.cfg
+++ b/default.cfg
@@ -5,11 +5,12 @@ map type=rom address=0xF80000 size=0x80000 file=kick.rom ovl=0
 # Want to map an extended ROM, such as CDTV or CD32?
 #map type=rom address=0xF00000 size=0x80000 file=cdtv.rom
 
-# Map 128MB of Fast RAM at 0x8000000.
-map type=ram address=0x08000000 size=128M id=cpu_slot_ram
+# Map 128MB of Fast RAM at 0x8000000, also known as 32-bit Fast RAM or CPU local Fast RAM.
+# Only supported properly on select Kickstarts, such as 3.1+ for Amiga 1200, 3000 and 4000.
+#map type=ram address=0x08000000 size=128M id=cpu_slot_ram
 # Map 128MB of Z3 Fast. Note that the address here is not actually used, as it gets auto-assigned by Kickstart itself.
-# Enabling Z3 fast requires a Kickstart that actually supports Zorro III, for instance from an A3000 or A4000.
-#map type=ram address=0x10000000 size=128M id=z3_autoconf_fast
+# Enabling Z3 fast requires at least Kickstart 2.0.
+map type=ram address=0x10000000 size=128M id=z3_autoconf_fast
 # Max 8MB of Z2 Fast can be mapped due to addressing space limitations, but for instance 2+4MB can be chained to leave 2MB for something else.
 #map type=ram address=0x200000 size=8M id=z2_autoconf_fast
 #map type=ram address=0x200000 size=2M id=z2_autoconf_fast

--- a/platforms/amiga/amiga-autoconf.c
+++ b/platforms/amiga/amiga-autoconf.c
@@ -86,13 +86,13 @@ unsigned char get_autoconf_size_ext(int size) {
 
 extern void adjust_ranges_amiga(struct emulator_config *cfg);
 
-unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned int address_) {
-  int address = address_ - AC_Z3_BASE;
+unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned int address) {
   int index = ac_z3_index[ac_z3_current_pic];
   unsigned char val = 0;
 
-  if ((address & 0xFF) >= AC_Z3_REG_RES50 && (address & 0xFF) <= AC_Z3_REG_RES7C)
+  if ((address & 0xFF) >= AC_Z3_REG_RES50 && (address & 0xFF) <= AC_Z3_REG_RES7C) {
     val = 0;
+  }
   else {
     switch(address & 0xFF) {
       case AC_Z3_REG_ER_TYPE:
@@ -146,6 +146,8 @@ unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned i
       case AC_Z3_REG_ER_RES0E:
       case AC_Z3_REG_ER_RES0F:
       case AC_Z3_REG_ER_Z2_INT:
+        val = 0;
+        break;
       default:
         val = 0;
         break;
@@ -157,8 +159,7 @@ unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned i
 
 int nib_latch = 0;
 
-void autoconfig_write_memory_z3_8(struct emulator_config *cfg, unsigned int address_, unsigned int value) {
-  int address = address_ - AC_Z3_BASE;
+void autoconfig_write_memory_z3_8(struct emulator_config *cfg, unsigned int address, unsigned int value) {
   int index = ac_z3_index[ac_z3_current_pic];
   unsigned char val = (unsigned char)value;
   int done = 0;
@@ -212,8 +213,7 @@ void autoconfig_write_memory_z3_8(struct emulator_config *cfg, unsigned int addr
   return;
 }
 
-void autoconfig_write_memory_z3_16(struct emulator_config *cfg, unsigned int address_, unsigned int value) {
-  int address = address_ - AC_Z3_BASE;
+void autoconfig_write_memory_z3_16(struct emulator_config *cfg, unsigned int address, unsigned int value) {
   int index = ac_z3_index[ac_z3_current_pic];
   unsigned short val = (unsigned short)value;
   int done = 0;
@@ -243,9 +243,8 @@ void autoconfig_write_memory_z3_16(struct emulator_config *cfg, unsigned int add
   return;
 }
 
-unsigned int autoconfig_read_memory_8(struct emulator_config *cfg, unsigned int address_) {
+unsigned int autoconfig_read_memory_8(struct emulator_config *cfg, unsigned int address) {
   unsigned char *rom = NULL;
-  int address = address_ - AC_Z2_BASE;
   unsigned char val = 0;
 
   switch(ac_z2_type[ac_z2_current_pic]) {
@@ -281,8 +280,7 @@ unsigned int autoconfig_read_memory_8(struct emulator_config *cfg, unsigned int 
   return (unsigned int)val;
 }
 
-void autoconfig_write_memory_8(struct emulator_config *cfg, unsigned int address_, unsigned int value) {
-  int address = address_ - AC_Z2_BASE;
+void autoconfig_write_memory_8(struct emulator_config *cfg, unsigned int address, unsigned int value) {
   int done = 0;
   int index = ac_z2_index[ac_z2_current_pic];
 

--- a/platforms/amiga/amiga-autoconf.h
+++ b/platforms/amiga/amiga-autoconf.h
@@ -84,6 +84,6 @@ enum autoconfg_z3_regs {
 unsigned int autoconfig_read_memory_8(struct emulator_config *cfg, unsigned int address);
 void autoconfig_write_memory_8(struct emulator_config *cfg, unsigned int address, unsigned int value);
 
-unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned int address_);
-void autoconfig_write_memory_z3_8(struct emulator_config *cfg, unsigned int address_, unsigned int value);
-void autoconfig_write_memory_z3_16(struct emulator_config *cfg, unsigned int address_, unsigned int value);
+unsigned int autoconfig_read_memory_z3_8(struct emulator_config *cfg, unsigned int address);
+void autoconfig_write_memory_z3_8(struct emulator_config *cfg, unsigned int address, unsigned int value);
+void autoconfig_write_memory_z3_16(struct emulator_config *cfg, unsigned int address, unsigned int value);


### PR DESCRIPTION
Allows Z3 Fast RAM to be configured in Z2 autoconf address space, appears to work with all Kickstarts down to 2.0 and eliminates the need for a Kickstart that supports CPU local/32-bit fast for more than 8MB of Fast RAM.