### PR TITLE
fix gcc 11 alignment link error : fix the gayle_emulation_enabled var…

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -54,7 +54,7 @@ uint8_t mouse_extra = 0;
 
 extern uint8_t gayle_int;
 extern uint8_t gayle_ide_enabled;
-extern uint8_t gayle_emulation_enabled;
+extern int gayle_emulation_enabled;
 extern uint8_t gayle_a4k_int;
 extern volatile unsigned int *gpio;
 extern volatile uint16_t srdata;

--- a/platforms/amiga/Gayle.c
+++ b/platforms/amiga/Gayle.c
@@ -84,7 +84,7 @@ uint8_t gayle_int = 0;
 uint32_t gayle_ide_mask = ~GDATA;
 uint32_t gayle_ide_base = GDATA;
 uint8_t gayle_ide_enabled = 1;
-uint8_t gayle_emulation_enabled = 1;
+int     gayle_emulation_enabled = 1;
 uint8_t gayle_ide_adj = 0;
 
 void adjust_gayle_4000() {


### PR DESCRIPTION
fix gcc 11 alignment link error : fix the gayle_emulation_enabled variable declaration : turn it to "int" everywhere. 
(was defined/used with two different types in the project : "uint8_t" and "int").