### PR TITLE
Make physical Zorro board detection optional

### DIFF
--- a/platforms/amiga/readme.md
+++ b/platforms/amiga/readme.md
@@ -94,3 +94,9 @@ Specifies the sample rate for the audio output on the Raspberry Pi. Defaults to 
 
 Example: `setvar swap-df0-df 1`  
 Swaps DF0 with DF1/2/3. Useful for Kickstart 1.x and/or Trackloader games that will only boot from DF0.
+
+# physical-z2-first
+
+Example: `setvar physical-z2-first`  
+Explicitly waits for physical (real) Zorro boards to initialize before initializing any of the virtual ones. This may be required for certain devices that are hard coded to assume that they're always in the first Z2 64KB IO memory slot range.  
+**Note:** Depending on what your particular computer returns when reading the AutoConfig registers, this may or may not work properly at all. Do not enable this if you're not sure what it is or does.


### PR DESCRIPTION
There is apparently no consistency whatsoever to the value reported when reading this register, and thus this can only be allowed to be enabled manually.