### PR TITLE
Fix m68k_write_memory_*

### DIFF
--- a/emulator.c
+++ b/emulator.c
@@ -1145,13 +1145,13 @@ void m68k_write_memory_16(unsigned int address, unsigned int value) {
     return;
 
   if (address & 0x01) {
-    ps_write_8(value & 0xFF, address);
-    ps_write_8((value >> 8) & 0xFF, address + 1);
+    ps_write_8((uint32_t)address, value & 0xFF);
+    ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
+    return;
+  } else {
+    ps_write_16((uint32_t)address, value);
     return;
   }
-
-  ps_write_16((uint32_t)address, value);
-  return;
 }
 
 void m68k_write_memory_32(unsigned int address, unsigned int value) {
@@ -1162,13 +1162,13 @@ void m68k_write_memory_32(unsigned int address, unsigned int value) {
     return;
 
   if (address & 0x01) {
-    ps_write_8(value & 0xFF, address);
-    ps_write_16(htobe16(((value >> 8) & 0xFFFF)), address + 1);
-    ps_write_8((value >> 24), address + 3);
+    ps_write_8((uint32_t)address, value & 0xFF);
+    ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
+    ps_write_8((uint32_t)address + 3, (value >> 24));
+    return;
+  } else {
+    ps_write_16((uint32_t)address, value >> 16);
+    ps_write_16((uint32_t)address + 2, value);
     return;
   }
-
-  ps_write_16(address, value >> 16);
-  ps_write_16(address + 2, value);
-  return;
 }

--- a/emulator.c
+++ b/emulator.c
@@ -1148,10 +1148,10 @@ void m68k_write_memory_16(unsigned int address, unsigned int value) {
     ps_write_8((uint32_t)address, value & 0xFF);
     ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
     return;
-  } else {
-    ps_write_16((uint32_t)address, value);
-    return;
   }
+
+  ps_write_16((uint32_t)address, value);
+  return;
 }
 
 void m68k_write_memory_32(unsigned int address, unsigned int value) {
@@ -1166,9 +1166,9 @@ void m68k_write_memory_32(unsigned int address, unsigned int value) {
     ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
     ps_write_8((uint32_t)address + 3, (value >> 24));
     return;
-  } else {
-    ps_write_16((uint32_t)address, value >> 16);
-    ps_write_16((uint32_t)address + 2, value);
-    return;
   }
+
+  ps_write_16((uint32_t)address, value >> 16);
+  ps_write_16((uint32_t)address + 2, value);
+  return;
 }

--- a/m68kcpu.h
+++ b/m68kcpu.h
@@ -1446,8 +1446,8 @@ static inline void m68ki_write_16_fc(m68ki_cpu_core *state, uint address, uint f
 #ifdef CHIP_FASTPATH
 	if (!state->ovl && address < 0x200000) {
 		if (address & 0x01) {
-			ps_write_8(value & 0xFF, address);
-			ps_write_8((value >> 8) & 0xFF, address + 1);
+			ps_write_8((uint32_t)address, value & 0xFF);
+			ps_write_8((uint32_t)address + 1, (value >> 8) & 0xFF);
 			return;
 		}
 		ps_write_16(address, value);
@@ -1490,9 +1490,9 @@ static inline void m68ki_write_32_fc(m68ki_cpu_core *state, uint address, uint f
 #ifdef CHIP_FASTPATH
 	if (!state->ovl && address < 0x200000) {
 		if (address & 0x01) {
-			ps_write_8(value & 0xFF, address);
-			ps_write_16(htobe16(((value >> 8) & 0xFFFF)), address + 1);
-			ps_write_8((value >> 24), address + 3);
+			ps_write_8((uint32_t)address, value & 0xFF);
+			ps_write_16((uint32_t)address + 1, htobe16(((value >> 8) & 0xFFFF)));
+			ps_write_8((uint32_t)address + 3, (value >> 24));
 			return;
 		}
 		ps_write_32(address, value);


### PR DESCRIPTION
There was some chaos leftover in m68k_write_memory_16 and m68k_write_memory_32
Namely, some of the calls had the args in the wrong places.