### PR TITLE
Configurable AS/An/Dn hold + build/test tooling (follow-up to #87)

### DIFF
--- a/build_svfs.sh
+++ b/build_svfs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Build the PiStorm Zorro II hold-variant bitstreams for both CPLDs.
+#
+# Nhold = HOLD_CLOCKS = N half-c7m steps of extra S6 hold (see rtl/pistorm.v):
+#   0hold stock   2hold +1 c7m (~long_hold)   3hold +1.5 c7m (~longer_hold)
+
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC=pistorm            # source project basename (.qpf/.qsf)
+REV=pistorm_build
+FAMS=(EPM240 EPM570)
+HOLDS=(0 2 3)          # HOLD_CLOCKS values = half-c7m steps
+RESET=$'\033[0m'       # Quartus leaves the terminal recoloured; undo it
+
+cd "$BASE_DIR/rtl"
+
+# Temp project file = the real one with only the revision name swapped.
+sed "s/^PROJECT_REVISION = .*/PROJECT_REVISION = \"$REV\"/" "$SRC.qpf" > "$REV.qpf"
+
+for fam in "${FAMS[@]}"; do
+  for n in "${HOLDS[@]}"; do
+    svf="${fam}_${n}hold.svf"
+    sed "s/^\(set_global_assignment -name DEVICE \).*/\1${fam}T100C5/" "$SRC.qsf" > "$REV.qsf"
+    echo -e "\nset_global_assignment -name VERILOG_MACRO \"HOLD_CLOCKS=$n\"" >> "$REV.qsf"
+    rm -rf db incremental_db output_files
+    echo
+    echo "${RESET}Building $svf.gz..."
+    ../quartus_docker_run.sh quartus_sh --flow compile "$REV"
+    ../quartus_docker_run.sh quartus_cpf -c -q 100KHz -g 3.3 -n p "output_files/$REV.pof" "$svf"
+    gzip -f "$svf"
+  done
+done

--- a/quartus_docker_install.sh
+++ b/quartus_docker_install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# One-time: install Quartus 20.1.1 Lite into ~/intelFPGA_lite, MAX II/V
+# device family only (PiStorm CPLDs are EPM240/EPM570 = MAX II), using the
+# stock raetro/quartus:base image (auto-pulled; no custom image needed).
+# Re-runnable. After this, run.sh / build_svfs.sh just consume the install.
+#
+# Env overrides:
+#   INSTALLER_DIR  unpacked Quartus tarball (default ~/Quartus-lite-20.1.1.720-linux)
+#   INSTALL_DIR    install target           (default ~/intelFPGA_lite)
+set -euo pipefail
+
+INSTALLER_DIR="${INSTALLER_DIR:-$HOME/Quartus-lite-20.1.1.720-linux}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/intelFPGA_lite}"
+
+mkdir -p "$INSTALL_DIR"
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -v "$INSTALLER_DIR":/installer:ro \
+  -v "$INSTALL_DIR":/opt/intelFPGA_lite \
+  -e HOME=/tmp \
+  -e LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4:/usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
+  raetro/quartus:base \
+  /installer/setup.sh --mode unattended --unattendedmodeui none \
+    --installdir /opt/intelFPGA_lite/20.1 --accept_eula 1 \
+    --disable-components quartus_help,arria_lite,cyclone,cyclone10lp,cyclonev,max10,quartus_update,modelsim_ase,modelsim_ae
+
+echo "Quartus installed in $INSTALL_DIR - you can now run ./build_svfs.sh"

--- a/quartus_docker_run.sh
+++ b/quartus_docker_run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Run a command in the Quartus container: stock raetro/quartus:base with the
+# host's Quartus bind-mounted in. The current directory is mounted as /work
+# and is the cwd, so cd to your project dir first. Usage:
+#   ./run.sh                  # interactive shell
+#   ./run.sh <command...>     # one-shot command
+# Env: INSTALL_DIR (Quartus install, default ~/intelFPGA_lite).
+set -e
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/intelFPGA_lite}"
+
+TTY_FLAG=""
+if [ -t 0 ]; then TTY_FLAG="-it"; fi
+
+# --user makes bind-mount writes host-owned; HOME=/tmp is writable for any
+# uid (Quartus drops license/config there); LD_PRELOAD is the tcmalloc fix
+# for Quartus 20.1's libsys_cpt udev double-free.
+exec docker run --rm $TTY_FLAG \
+    --user "$(id -u):$(id -g)" \
+    -v "$INSTALL_DIR":/opt/intelFPGA_lite \
+    -v "$PWD":/work \
+    -w /work \
+    -e HOME=/tmp \
+    -e PATH=/opt/intelFPGA_lite/20.1/quartus/bin:/usr/local/bin:/usr/bin:/bin \
+    -e LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4:/usr/lib/x86_64-linux-gnu/libstdc++.so.6 \
+    raetro/quartus:base "$@"

--- a/rtl/pistorm.qsf
+++ b/rtl/pistorm.qsf
@@ -118,6 +118,11 @@ set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to M68K_IPL_n[0]
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to M68K_IPL_n[1]
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to M68K_IPL_n[2]
 set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to CLK_SEL
+# Stock pistorm.v never sampled BR/BGACK, so floating was harmless. We now
+# use them, so enable internal pullups to backstop the motherboard's external
+# ones — keeps the long CPLD-to-CPU-socket trace from picking up DMA noise.
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to M68K_BR_n
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to M68K_BGACK_n
 
 set_global_assignment -name AUTO_RESTART_CONFIGURATION OFF
 set_global_assignment -name ENABLE_OCT_DONE OFF

--- a/rtl/pistorm.sdc
+++ b/rtl/pistorm.sdc
@@ -84,7 +84,7 @@ create_clock -name {M68K_C3} -period 282.000 [get_ports {M68K_C3}]
 # Set False Path
 #**************************************************************
 
-set_false_path -from [get_ports {M68K_CLK M68K_DTACK_n M68K_VPA_n M68K_IPL_n[*] PI_A[*] PI_D[*] PI_RD PI_WR}]
+set_false_path -from [get_ports {M68K_CLK M68K_DTACK_n M68K_VPA_n M68K_IPL_n[*] M68K_BR_n M68K_BGACK_n PI_A[*] PI_D[*] PI_RD PI_WR}]
 set_false_path -to [get_ports {LTCH_A_0 LTCH_A_8 LTCH_A_16 LTCH_A_24 LTCH_A_OE_n LTCH_D_RD_L LTCH_D_RD_OE_n LTCH_D_RD_U LTCH_D_WR_L LTCH_D_WR_OE_n LTCH_D_WR_U M68K_AS_n M68K_BG_n M68K_E M68K_FC[*] M68K_HALT_n M68K_LDS_n M68K_RESET_n M68K_RW M68K_UDS_n M68K_VMA_n PI_TXN_IN_PROGRESS PI_IPL_ZERO PI_D[*]}]
 
 set_false_path -from [get_clocks {M68K_CLK}] -to [get_clocks {PI_CLK}]

--- a/rtl/pistorm.v
+++ b/rtl/pistorm.v
@@ -25,12 +25,12 @@ module pistorm(
     output reg      LTCH_D_WR_OE_n,
 
     input           M68K_CLK,
-    output  reg [2:0] M68K_FC,
+    inout       [2:0] M68K_FC,
 
-    output reg      M68K_AS_n,
-    output reg      M68K_UDS_n,
-    output reg      M68K_LDS_n,
-    output reg      M68K_RW,
+    inout           M68K_AS_n,
+    inout           M68K_UDS_n,
+    inout           M68K_LDS_n,
+    inout           M68K_RW,
 
     input           M68K_DTACK_n,
     input           M68K_BERR_n,
@@ -63,15 +63,31 @@ module pistorm(
   localparam REG_ADDR_HI = 2'd2;
   localparam REG_STATUS = 2'd3;
 
+  // Bus ownership: 1 = PiStorm drives the 68k bus, 0 = released to another master.
+  reg       bus_owned = 1'b1;
+
+  // Internal shadow regs for the tri-stateable CPU signals.
+  reg [2:0] fc_r    = 3'd0;
+  reg       as_n_r  = 1'b1;
+  reg       uds_n_r = 1'b1;
+  reg       lds_n_r = 1'b1;
+  reg       rw_r    = 1'b1;
+
+  assign M68K_FC    = bus_owned ? fc_r    : 3'bzzz;
+  assign M68K_AS_n  = bus_owned ? as_n_r  : 1'bz;
+  assign M68K_UDS_n = bus_owned ? uds_n_r : 1'bz;
+  assign M68K_LDS_n = bus_owned ? lds_n_r : 1'bz;
+  assign M68K_RW    = bus_owned ? rw_r    : 1'bz;
+
   initial begin
     PI_TXN_IN_PROGRESS <= 1'b0;
     PI_IPL_ZERO <= 1'b0;
 
     PI_RESET <= 1'b0;
 
-    M68K_FC <= 3'd0;
+    fc_r <= 3'd0;
 
-    M68K_RW <= 1'b1;
+    rw_r <= 1'b1;
 
     M68K_E <= 1'b0;
     M68K_VMA_n <= 1'b1;
@@ -91,6 +107,7 @@ module pistorm(
   wire wr_rising = !wr_sync[1] && wr_sync[0];
 
   reg [15:0] data_out;
+  reg [2:0]  ipl;  // forward-declared so iverilog accepts the use below; full def further down
   assign PI_D = PI_A == REG_STATUS && PI_RD ? data_out : 16'bz;
 
   always @(posedge c200m) begin
@@ -132,7 +149,6 @@ module pistorm(
   wire c7m_rising = !c7m_sync[2] && c7m_sync[1];
   wire c7m_falling = c7m_sync[2] && !c7m_sync[1];
 
-  reg [2:0] ipl;
   reg [2:0] ipl_1;
   reg [2:0] ipl_2;
 
@@ -171,8 +187,58 @@ module pistorm(
   reg [2:0] state = 3'd0;
   reg [2:0] PI_TXN_IN_PROGRESS_delay;
 
+  // -------- Bus arbitration (BR/BG/BGACK) --------
+  // Two-flop synchronizers for async inputs from the other master.
+  reg [1:0] br_sync    = 2'b11;
+  reg [1:0] bgack_sync = 2'b11;
+  always @(posedge c200m) begin
+    br_sync    <= {br_sync[0],    M68K_BR_n};
+    bgack_sync <= {bgack_sync[0], M68K_BGACK_n};
+  end
+  wire br_n_s    = br_sync[1];
+  wire bgack_n_s = bgack_sync[1];
+
+  // We only release the bus at a clean boundary: parked in the wait-for-op
+  // state with AS deasserted and no queued op. S0 only lasts one PI_CLK and
+  // unconditionally falls into S1, where the FSM idles until op_req goes high
+  // — so S1 (or transiently S0) is the right place to grant. LTCH_*_OE_n are
+  // already raised by S7 before we get here.
+  wire bus_idle = (state == 3'd0 || state == 3'd1) && as_n_r && !op_req;
+
+  localparam ARB_IDLE     = 2'd0;
+  localparam ARB_GRANTING = 2'd1;  // BG asserted, waiting for BGACK
+  localparam ARB_RELEASED = 2'd2;  // BGACK asserted, off the bus
+  reg [1:0] arb_state = ARB_IDLE;
+
+  always @(posedge c200m) begin
+    case (arb_state)
+      ARB_IDLE: begin
+        if (!br_n_s && bus_idle) begin
+          M68K_BG_n <= 1'b0;       // grant
+          arb_state <= ARB_GRANTING;
+        end
+      end
+      ARB_GRANTING: begin
+        if (!bgack_n_s) begin
+          bus_owned <= 1'b0;       // tri-state CPU-driven signals
+          M68K_BG_n <= 1'b1;       // BG can be released once BGACK is asserted
+          arb_state <= ARB_RELEASED;
+        end
+      end
+      ARB_RELEASED: begin
+        if (bgack_n_s) begin       // other master finished
+          bus_owned <= 1'b1;
+          arb_state <= ARB_IDLE;
+        end
+      end
+      default: arb_state <= ARB_IDLE;
+    endcase
+  end
+
   always @(posedge c200m) begin
 
+    // Always accept Pi register writes — the Pi can queue an op while
+    // we're released; it will execute once the bus comes back.
     if (wr_rising) begin
       case (PI_A)
         REG_ADDR_LO: begin
@@ -191,9 +257,13 @@ module pistorm(
       endcase
     end
 
+    // 68k cycle FSM. We only block the S1->S2 advance when we don't own the
+    // bus (gating the whole FSM here added ~1.6 ns to every next-state path).
+    // The arbiter is guaranteed to release only at S0, so the FSM will be
+    // parked at S0 or S1 (the wait-for-op state) when bus_owned drops.
     case (state)
       3'd0: begin // S0
-        M68K_RW <= 1'b1; // S7 -> S0
+        rw_r <= 1'b1; // S7 -> S0
 //        if (c7m_falling) begin
 //          if (op_req) begin
             state <= 2'd1;
@@ -202,22 +272,27 @@ module pistorm(
       end
 
       3'd1: begin // S1
-        if (op_req) begin
+        // Only start a new 68k cycle when the arbiter is idle. This is
+        // strictly tighter than gating on bus_owned alone: it also blocks
+        // new cycles while BG is asserted and we're waiting for BGACK
+        // (the ARB_GRANTING window), which a real 68k won't do either.
+        // ARB_IDLE implies bus_owned == 1, so the bus_owned term is folded in.
+        if (op_req && arb_state == ARB_IDLE) begin
           if(c7m_rising) begin
             state <= 3'd2;
           end
         end
       end
       3'd2: begin // S2
-        M68K_RW <= op_rw; // S1 -> S2
+        rw_r <= op_rw; // S1 -> S2
         LTCH_D_WR_OE_n <= op_rw;
         LTCH_A_OE_n <= 1'b0;
-        M68K_AS_n <= 1'b0;
-        M68K_UDS_n <= op_rw ? op_uds_n : 1'b1;
-        M68K_LDS_n <= op_rw ? op_lds_n : 1'b1;
+        as_n_r <= 1'b0;
+        uds_n_r <= op_rw ? op_uds_n : 1'b1;
+        lds_n_r <= op_rw ? op_lds_n : 1'b1;
         if (c7m_falling) begin
-          M68K_UDS_n <= op_uds_n;
-          M68K_LDS_n <= op_lds_n;
+          uds_n_r <= op_uds_n;
+          lds_n_r <= op_lds_n;
           state <= 3'd3;
         end
       end
@@ -265,11 +340,11 @@ module pistorm(
       3'd7: begin // S7
         LTCH_D_WR_OE_n <= 1'b1;
         LTCH_A_OE_n <= 1'b1;
-        M68K_AS_n <= 1'b1;
-        M68K_UDS_n <= 1'b1;
-        M68K_LDS_n <= 1'b1;
+        as_n_r <= 1'b1;
+        uds_n_r <= 1'b1;
+        lds_n_r <= 1'b1;
 //        if(c7m_rising) begin
-//          M68K_RW <= 1'b1; // S7 -> S0
+//          rw_r <= 1'b1; // S7 -> S0
           state <= 3'd0;
 //        end
       end

--- a/rtl/pistorm.v
+++ b/rtl/pistorm.v
@@ -2,6 +2,17 @@
  * Copyright 2020 Claude Schwarz
  * Copyright 2020 Niklas Ekström - rewrite in Verilog
  */
+
+// Extra bus-access hold: HOLD_CLOCKS half-c7m steps added in S6 to every
+// 68k cycle, holding AS / address / data longer before deassert. Meant to
+// help Zorro II cards that mishandle the PiStorm's very short bus cycles
+// (e.g. GVP RAM). Default 0 = stock, so scripts that don't set it (e.g.
+// the Windows make.bat) keep working.
+//   0 = stock   2 = +1 c7m   3 = +1.5 c7m
+`ifndef HOLD_CLOCKS
+`define HOLD_CLOCKS 0
+`endif
+
 module pistorm(
     output reg      PI_TXN_IN_PROGRESS, // GPIO0
     output reg      PI_IPL_ZERO,        // GPIO1
@@ -186,6 +197,11 @@ module pistorm(
 
   reg [2:0] state = 3'd0;
   reg [2:0] PI_TXN_IN_PROGRESS_delay;
+  // Bus-access hold depth, in half-c7m steps. At HOLD_N==0 the S6 compare
+  // folds to a constant and synthesis prunes s6_hold_cnt, so 0 == the
+  // original counter-free logic.
+  localparam HOLD_N = `HOLD_CLOCKS;
+  reg [2:0] s6_hold_cnt = 3'd0;   // half-c7m hold counter - see S6
 
   // -------- Bus arbitration (BR/BG/BGACK) --------
   // Two-flop synchronizers for async inputs from the other master.
@@ -330,10 +346,18 @@ module pistorm(
         end
       end
        
-      3'd6: begin // S6
-        if (c7m_falling) begin
-          M68K_VMA_n <= 1'b1;
-          state <= 3'd7;
+      3'd6: begin // S6 - bus-access hold (HOLD_CLOCKS half-c7m steps).
+        // Stock exits on the first c7m edge; each extra step holds AS /
+        // address / data one more half c7m (~70 ns) before S7 deasserts.
+        // Counting both c7m edges gives the half-c7m resolution.
+        if (c7m_rising || c7m_falling) begin
+          if (HOLD_N == 0 || s6_hold_cnt == HOLD_N) begin
+            s6_hold_cnt <= 3'd0;
+            M68K_VMA_n <= 1'b1;
+            state <= 3'd7;
+          end else begin
+            s6_hold_cnt <= s6_hold_cnt + 3'd1;
+          end
         end
       end
        

--- a/rtl/pistorm_tb.v
+++ b/rtl/pistorm_tb.v
@@ -1,0 +1,355 @@
+// Testbench for pistorm.v — focuses on the BR/BG/BGACK arbitration logic
+// added on top of the existing CPU-cycle FSM.
+//
+// Run:
+//   iverilog -g2012 -o pistorm_tb pistorm_tb.v pistorm.v
+//   vvp pistorm_tb            # text log to stdout
+//   gtkwave pistorm_tb.vcd    # waveform viewer
+
+`timescale 1ns/100ps
+
+module pistorm_tb;
+
+  // --- Clocks ---
+  reg PI_CLK = 0;            // 200 MHz
+  reg M68K_CLK = 0;          //   7.09 MHz (141 ns period per SDC)
+  always #2.5  PI_CLK   = ~PI_CLK;
+  always #70.5 M68K_CLK = ~M68K_CLK;
+
+  // --- DUT I/O ---
+  reg  [1:0]  PI_A = 0;
+  reg         PI_RD = 0;
+  reg         PI_WR = 0;
+  wire [15:0] PI_D;             // inout
+  reg  [15:0] pi_d_drv = 16'bz; // host-side driver
+  reg         pi_d_drv_en = 0;
+  assign PI_D = pi_d_drv_en ? pi_d_drv : 16'bz;
+
+  wire        PI_TXN_IN_PROGRESS, PI_IPL_ZERO, PI_RESET;
+
+  // The 68k bus signals are mostly bidirectional; model the wired-OR / open
+  // collector with pullups so any side can pull them low.
+  wire [2:0]  M68K_FC;
+  wire        M68K_AS_n;
+  wire        M68K_UDS_n;
+  wire        M68K_LDS_n;
+  wire        M68K_RW;
+  pullup(M68K_AS_n);
+  pullup(M68K_UDS_n);
+  pullup(M68K_LDS_n);
+  pullup(M68K_RW);
+
+  // DTACK / VPA / BERR / IPL: driven by the testbench standing in for the
+  // Amiga motherboard.
+  reg         dtack_drv_n = 1'bz; assign (pull0,pull1) M68K_DTACK_n_w = dtack_drv_n;
+  wire        M68K_DTACK_n; assign M68K_DTACK_n = dtack_drv_n;
+  reg         M68K_VPA_n = 1'b1;
+  reg         M68K_BERR_n = 1'b1;
+  reg  [2:0]  M68K_IPL_n = 3'b111;
+  wire        M68K_E, M68K_VMA_n;
+
+  // RESET / HALT are open-drain on the Amiga; let the DUT and the TB share.
+  wire        M68K_RESET_n; pullup(M68K_RESET_n);
+  wire        M68K_HALT_n;  pullup(M68K_HALT_n);
+
+  // BR / BGACK are inputs to the DUT (we drive them as a fake bus master);
+  // BG is an output from the DUT.
+  reg         M68K_BR_n    = 1'b1;
+  wire        M68K_BG_n;
+  reg         M68K_BGACK_n = 1'b1;
+
+  // C1/C3/CLK_SEL — pick simple M68K_CLK passthrough.
+  reg         M68K_C1 = 0, M68K_C3 = 0;
+  reg         CLK_SEL = 1'b1;  // use M68K_CLK directly
+
+  // --- Latch / address-bus model (just enough to satisfy the DUT) ---
+  wire LTCH_A_0, LTCH_A_8, LTCH_A_16, LTCH_A_24, LTCH_A_OE_n;
+  wire LTCH_D_RD_U, LTCH_D_RD_L, LTCH_D_RD_OE_n;
+  wire LTCH_D_WR_U, LTCH_D_WR_L, LTCH_D_WR_OE_n;
+
+  // --- DUT ---
+  pistorm dut(
+    .PI_TXN_IN_PROGRESS(PI_TXN_IN_PROGRESS),
+    .PI_IPL_ZERO(PI_IPL_ZERO),
+    .PI_A(PI_A), .PI_CLK(PI_CLK), .PI_RESET(PI_RESET),
+    .PI_RD(PI_RD), .PI_WR(PI_WR), .PI_D(PI_D),
+    .LTCH_A_0(LTCH_A_0), .LTCH_A_8(LTCH_A_8),
+    .LTCH_A_16(LTCH_A_16), .LTCH_A_24(LTCH_A_24),
+    .LTCH_A_OE_n(LTCH_A_OE_n),
+    .LTCH_D_RD_U(LTCH_D_RD_U), .LTCH_D_RD_L(LTCH_D_RD_L),
+    .LTCH_D_RD_OE_n(LTCH_D_RD_OE_n),
+    .LTCH_D_WR_U(LTCH_D_WR_U), .LTCH_D_WR_L(LTCH_D_WR_L),
+    .LTCH_D_WR_OE_n(LTCH_D_WR_OE_n),
+    .M68K_CLK(M68K_CLK), .M68K_FC(M68K_FC),
+    .M68K_AS_n(M68K_AS_n), .M68K_UDS_n(M68K_UDS_n),
+    .M68K_LDS_n(M68K_LDS_n), .M68K_RW(M68K_RW),
+    .M68K_DTACK_n(M68K_DTACK_n), .M68K_BERR_n(M68K_BERR_n),
+    .M68K_VPA_n(M68K_VPA_n), .M68K_E(M68K_E), .M68K_VMA_n(M68K_VMA_n),
+    .M68K_IPL_n(M68K_IPL_n),
+    .M68K_RESET_n(M68K_RESET_n), .M68K_HALT_n(M68K_HALT_n),
+    .M68K_BR_n(M68K_BR_n), .M68K_BG_n(M68K_BG_n), .M68K_BGACK_n(M68K_BGACK_n),
+    .M68K_C1(M68K_C1), .M68K_C3(M68K_C3), .CLK_SEL(CLK_SEL)
+  );
+
+  // --- Fake slave: drop DTACK when AS asserts ---
+  always @(negedge M68K_AS_n) begin
+    repeat (3) @(posedge M68K_CLK);   // 3 clk delay, like real RAM
+    dtack_drv_n <= 1'b0;
+  end
+  always @(posedge M68K_AS_n) dtack_drv_n <= 1'bz;
+
+  // --- Helpers ---
+  task pi_write(input [1:0] a, input [15:0] d);
+    begin
+      @(posedge PI_CLK); #1;
+      PI_A <= a; pi_d_drv <= d; pi_d_drv_en <= 1'b1;
+      PI_WR <= 1'b1;
+      @(posedge PI_CLK); #1;
+      PI_WR <= 1'b0;
+      @(posedge PI_CLK); #1;
+      pi_d_drv_en <= 1'b0;
+    end
+  endtask
+
+  // Issue a 68k read of address `addr`. ADDR_LO carries low 16 bits + a0,
+  // ADDR_HI carries high 8 bits + control bits (bit9 = read, bit8 = byte).
+  task pi_cpu_read_word(input [23:0] addr);
+    begin
+      pi_write(2'd1, {addr[15:0]});
+      pi_write(2'd2, {6'b0, 1'b1 /*read*/, 1'b0 /*word*/, addr[23:16]});
+    end
+  endtask
+
+  // --- Protocol checks ---
+  reg fail = 0;
+  task fail_if(input cond, input [255:0] msg);
+    begin
+      if (cond) begin
+        $display("[FAIL @ %0t] %0s", $time, msg);
+        fail = 1;
+      end
+    end
+  endtask
+
+  // Whenever we don't own the bus, the DUT must NOT drive AS/UDS/LDS/RW.
+  // (Sampled on PI_CLK to filter sim-time glitches around tri-state handoff.)
+  always @(posedge PI_CLK) begin
+    if (dut.bus_owned == 1'b0) begin
+      fail_if(M68K_AS_n  !== 1'b1, "AS_n driven low while bus released");
+      fail_if(M68K_UDS_n !== 1'b1, "UDS_n driven low while bus released");
+      fail_if(M68K_LDS_n !== 1'b1, "LDS_n driven low while bus released");
+    end
+  end
+
+  // BG must only assert at a clean idle point (FSM in S0/S1 wait, AS high).
+  always @(negedge M68K_BG_n) begin
+    fail_if(!(dut.state == 3'd0 || dut.state == 3'd1),
+            "BG asserted while FSM not in S0/S1 wait");
+    fail_if(M68K_AS_n  !== 1'b1, "BG asserted while AS still low");
+  end
+
+  // --- Main stimulus ---
+  initial begin
+    $dumpfile("pistorm_tb.vcd");
+    $dumpvars(0, pistorm_tb);
+
+    // Release reset
+    pi_write(2'd3, 16'h0002); // REG_STATUS bit1=1 -> reset_out=0
+    #200;
+
+    // ----- Scenario 1: normal CPU read, no BR -----
+    $display("[%0t] Scenario 1: normal CPU read", $time);
+    pi_cpu_read_word(24'h00_1234);
+    // Wait for the cycle to complete
+    wait (PI_TXN_IN_PROGRESS == 1'b1);
+    wait (PI_TXN_IN_PROGRESS == 1'b0);
+    $display("[%0t]   cycle completed (state=%0d)", $time, dut.state);
+
+    #200;
+
+    // ----- Scenario 2: external master requests bus -----
+    $display("[%0t] Scenario 2: BR while idle", $time);
+    M68K_BR_n <= 1'b0;
+    wait (M68K_BG_n == 1'b0);
+    $display("[%0t]   BG asserted (state=%0d, arb=%0d)",
+             $time, dut.state, dut.arb_state);
+
+    // Pretend to be the requester: pull BGACK low
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b0;
+    M68K_BR_n    <= 1'b1;  // requester drops BR once BGACK is in
+
+    wait (dut.bus_owned == 1'b0);
+    $display("[%0t]   bus released (BG_n=%b, bus_owned=%b)",
+             $time, M68K_BG_n, dut.bus_owned);
+    fail_if(M68K_BG_n !== 1'b1, "BG should be deasserted after BGACK");
+
+    // ----- Scenario 3: queue an op while we don't own the bus -----
+    $display("[%0t] Scenario 3: queue a CPU op while released", $time);
+    pi_cpu_read_word(24'h00_5678);
+    #500;
+    fail_if(dut.state !== 3'd1 && dut.state !== 3'd0,
+            "FSM advanced past S1 while bus released");
+    $display("[%0t]   FSM parked at state=%0d as expected", $time, dut.state);
+
+    // Release the bus back to the DUT
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b1;
+
+    wait (dut.bus_owned == 1'b1);
+    $display("[%0t]   bus reclaimed", $time);
+
+    // Queued op should now run
+    wait (M68K_AS_n == 1'b0);
+    $display("[%0t]   queued cycle started (AS low)", $time);
+    wait (PI_TXN_IN_PROGRESS == 1'b0);
+    $display("[%0t]   queued cycle completed", $time);
+
+    #400;
+
+    // ----- Scenario 4: BR asserted mid-CPU-cycle -----
+    // Start a CPU read, then assert BR while AS is still low. Arbiter must
+    // not grant until the cycle finishes (AS goes high again).
+    $display("[%0t] Scenario 4: BR asserted mid-cycle", $time);
+    pi_cpu_read_word(24'h00_9abc);
+    wait (M68K_AS_n == 1'b0);
+    $display("[%0t]   AS asserted, now raising BR", $time);
+    M68K_BR_n <= 1'b0;
+    // BG must NOT assert while AS is low. The assertion at line 145 catches
+    // this continuously; we just need to wait and check it didn't fire.
+    wait (M68K_AS_n == 1'b1);
+    $display("[%0t]   cycle done (state=%0d), expecting BG soon", $time, dut.state);
+    wait (M68K_BG_n == 1'b0);
+    $display("[%0t]   BG granted (state=%0d)", $time, dut.state);
+
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b0;
+    M68K_BR_n    <= 1'b1;
+    wait (dut.bus_owned == 1'b0);
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b1;
+    wait (dut.bus_owned == 1'b1);
+    $display("[%0t]   released and reclaimed", $time);
+
+    #400;
+
+    // ----- Scenario 5: BR pulsed briefly (request retracted) -----
+    // If BR drops back high before BG is granted, the arbiter shouldn't grant.
+    // It might still grant if BR was sampled low through the synchronizer —
+    // that's spec-compliant (grant honors any seen request), so this is a
+    // soft check: we just observe what happens.
+    $display("[%0t] Scenario 5: BR pulsed briefly", $time);
+    M68K_BR_n <= 1'b0;
+    repeat (1) @(posedge PI_CLK);    // 1 PI_CLK only — likely not through the 2-flop sync
+    M68K_BR_n <= 1'b1;
+    repeat (50) @(posedge PI_CLK);
+    if (M68K_BG_n == 1'b0) begin
+      $display("[%0t]   BG asserted from brief pulse (spec-compliant); completing handshake", $time);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b0;
+      wait (dut.bus_owned == 1'b0);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b1;
+      wait (dut.bus_owned == 1'b1);
+    end else begin
+      $display("[%0t]   pulse was filtered (BG stayed high) — OK", $time);
+    end
+
+    #400;
+
+    // ----- Scenario 6: BG granted but BGACK never comes -----
+    // If the bus master crashes/never asserts BGACK, the arbiter should stay
+    // in ARB_GRANTING with BG asserted but not yet release the bus. Verify
+    // that and then have the master finally ack to recover.
+    $display("[%0t] Scenario 6: BG granted, BGACK delayed", $time);
+    M68K_BR_n <= 1'b0;
+    wait (M68K_BG_n == 1'b0);
+    $display("[%0t]   BG asserted, withholding BGACK for ~1us", $time);
+    repeat (200) @(posedge PI_CLK);
+    fail_if(dut.bus_owned !== 1'b1, "bus_owned dropped without BGACK");
+    fail_if(dut.arb_state !== 2'd1 /*ARB_GRANTING*/, "arb_state left ARB_GRANTING without BGACK");
+    $display("[%0t]   arb still in GRANTING (arb=%0d, bus_owned=%b), now sending BGACK",
+             $time, dut.arb_state, dut.bus_owned);
+
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b0;
+    M68K_BR_n    <= 1'b1;
+    wait (dut.bus_owned == 1'b0);
+    @(posedge PI_CLK); #1;
+    M68K_BGACK_n <= 1'b1;
+    wait (dut.bus_owned == 1'b1);
+    $display("[%0t]   recovered after delayed BGACK", $time);
+
+    #400;
+
+    // ----- Scenario 7: two grants back-to-back -----
+    $display("[%0t] Scenario 7: two grants back-to-back", $time);
+    repeat (2) begin : two_grants
+      integer i;
+      M68K_BR_n <= 1'b0;
+      wait (M68K_BG_n == 1'b0);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b0;
+      M68K_BR_n    <= 1'b1;
+      wait (dut.bus_owned == 1'b0);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b1;
+      wait (dut.bus_owned == 1'b1);
+      for (i = 0; i < 20; i = i + 1) @(posedge PI_CLK);
+    end
+    $display("[%0t]   two grants completed cleanly", $time);
+
+    #400;
+
+    // ----- Scenario 8: BR asserted just before a queued op would advance ---
+    // Pi queues an op; in the same window, BR is asserted. The arbiter must
+    // wait for the in-flight cycle to finish before granting (S1 → S2 with
+    // bus_owned still high is allowed if BR is just freshly synchronized).
+    $display("[%0t] Scenario 8: BR coincident with queued op", $time);
+    fork
+      begin
+        pi_cpu_read_word(24'h00_dead);
+      end
+      begin
+        @(posedge PI_CLK); #1;
+        M68K_BR_n <= 1'b0;
+      end
+    join
+
+    // Let the system settle a bit so we can see who won the race.
+    repeat (20) @(posedge PI_CLK);
+
+    // Two valid orderings:
+    //   (a) BR won — BG is asserted, FSM stalled in S1; we run the
+    //       arbitration handshake first, then the queued op completes after.
+    //   (b) The op started before BR was synchronized — cycle is in flight.
+    if (M68K_BG_n == 1'b0) begin
+      $display("[%0t]   BR won race; completing handshake first", $time);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b0;
+      M68K_BR_n    <= 1'b1;
+      wait (dut.bus_owned == 1'b0);
+      @(posedge PI_CLK); #1;
+      M68K_BGACK_n <= 1'b1;
+      wait (dut.bus_owned == 1'b1);
+    end else begin
+      $display("[%0t]   op won race; cycle already in flight", $time);
+      M68K_BR_n <= 1'b1;
+    end
+
+    wait (M68K_AS_n == 1'b0);          // queued op finally runs
+    wait (PI_TXN_IN_PROGRESS == 1'b0); // and completes
+    $display("[%0t]   queued op completed", $time);
+
+    #400;
+    if (fail) $display("==== FAILED ====");
+    else      $display("==== PASSED ====");
+    $finish;
+  end
+
+  initial begin
+    #500000 $display("[%0t] TIMEOUT", $time);
+    $fatal;
+  end
+
+endmodule

--- a/verify_verilog.sh
+++ b/verify_verilog.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Compile + run the pistorm testbench across every HOLD_CLOCKS variant with
+# Icarus Verilog (no Quartus/Docker needed). Exits non-zero if any variant's
+# testbench does not report PASSED. Run from anywhere.
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$BASE_DIR/rtl"
+
+rc=0
+# default + shipped values (0/2/3) + 4 (old full-+2, A500-bad on HW but must
+# still complete in sim - regression guard that the FSM never wedges).
+for d in default 0 2 3 4; do
+  if [ "$d" = default ]; then
+    m="" ; label="default (ifndef -> 0)"
+  else
+    m="-DHOLD_CLOCKS=$d" ; label="HOLD_CLOCKS=$d"
+  fi
+  tb="$(mktemp)"
+  iverilog -g2012 $m -o "$tb" pistorm_tb.v pistorm.v
+  out="$(vvp "$tb" 2>&1 || true)"
+  rm -f "$tb"
+  if grep -q '==== PASSED ====' <<<"$out"; then
+    echo "PASS  $label"
+  else
+    echo "FAIL  $label"
+    echo "$out" | tail -20
+    rc=1
+  fi
+done
+exit $rc


### PR DESCRIPTION
Adds a configurable hold on AS / An / Dn (HOLD_CLOCKS Verilog macro, default 0 = stock, so existing build entrypoints are unaffected), for Zorro II cards that mishandle the PiStorm's very short bus cycles.

Draft, stacked on #87: until #87 merges this diff also shows the arbitration commit; review/merge #87 first.

Build/test infra:
- quartus_docker_install.sh / quartus_docker_run.sh: install and run Quartus Lite 20.1.1.720 via the stock raetro/quartus:base image.
- build_svfs.sh: build {EPM240,EPM570} x {0,2,3}hold .svf.gz; does not mutate the tracked pistorm.qsf.
- verify_verilog.sh: run rtl/pistorm_tb.v under Icarus Verilog across HOLD_CLOCKS variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code) - which is way better than me at Verilog, but still kinda sucks at keeping bash scripts small & simple :-)